### PR TITLE
Add emoji picker with keyboard shortcut

### DIFF
--- a/data/50-gnome-shell-emoji.xml
+++ b/data/50-gnome-shell-emoji.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<KeyListEntries schema="org.gnome.shell.keybindings"
+                group="system"
+                name="Emoji"
+                wm_name="GNOME Shell"
+                package="gnome-shell">
+
+    <KeyListEntry name="emoji-picker"
+                  description="Open the emoji picker"/>
+</KeyListEntries>

--- a/data/meson.build
+++ b/data/meson.build
@@ -98,6 +98,7 @@ keybinding_files = [
   '50-gnome-shell-launchers.xml',
   '50-gnome-shell-screenshots.xml',
   '50-gnome-shell-system.xml',
+  '50-gnome-shell-emoji.xml',
 ]
 
 install_data(keybinding_files, install_dir: keysdir)

--- a/data/org.gnome.shell.gschema.xml.in
+++ b/data/org.gnome.shell.gschema.xml.in
@@ -278,6 +278,10 @@
       <default>["&lt;Shift&gt;Print"]</default>
       <summary>Take a screenshot</summary>
     </key>
+    <key name="emoji-picker" type="as">
+      <default>["&lt;Ctrl&gt;&lt;Alt&gt;space","&lt;Super&gt;."]</default>
+      <summary>Open the emoji picker</summary>
+    </key>
   </schema>
 
   <schema id="org.gnome.shell.app-switcher"

--- a/js/js-resources.gresource.xml
+++ b/js/js-resources.gresource.xml
@@ -77,6 +77,7 @@
     <file>ui/init.js</file>
     <file>ui/kbdA11yDialog.js</file>
     <file>ui/keyboard.js</file>
+    <file>ui/emojiPicker.js</file>
     <file>ui/layout.js</file>
     <file>ui/lightbox.js</file>
     <file>ui/listModes.js</file>

--- a/js/ui/emojiPicker.js
+++ b/js/ui/emojiPicker.js
@@ -1,0 +1,59 @@
+import Clutter from 'gi://Clutter';
+import Gio from 'gi://Gio';
+import GObject from 'gi://GObject';
+import Meta from 'gi://Meta';
+import Shell from 'gi://Shell';
+import St from 'gi://St';
+
+import * as BoxPointer from './boxpointer.js';
+import * as Main from './main.js';
+import {EmojiSelection} from './keyboard.js';
+
+export const EmojiPicker = GObject.registerClass({
+    Signals: { 'emoji-selected': { param_types: [GObject.TYPE_STRING] } },
+}, class EmojiPicker extends St.Widget {
+    _init() {
+        super._init({ visible: false });
+
+        this._dummyCursor = new Clutter.Actor({ opacity: 0 });
+        Main.layoutManager.uiGroup.add_child(this._dummyCursor);
+
+        this._boxPointer = new BoxPointer.BoxPointer(St.Side.TOP);
+        this._boxPointer.hide();
+        Main.layoutManager.addTopChrome(this._boxPointer);
+
+        this._selection = new EmojiSelection();
+        this._selection.connect('emoji-selected', (_s, emoji) => {
+            this.emit('emoji-selected', emoji);
+            this.close();
+        });
+        this._selection.connect('close-request', () => this.close());
+        this._boxPointer.bin.set_child(this._selection);
+
+        const uiModes = Shell.ActionMode.ALL & ~Shell.ActionMode.LOGIN_SCREEN;
+        Main.wm.addKeybinding(
+            'emoji-picker',
+            new Gio.Settings({ schema_id: 'org.gnome.shell.keybindings' }),
+            Meta.KeyBindingFlags.IGNORE_AUTOREPEAT,
+            uiModes,
+            () => this.openAtPointer()
+        );
+    }
+
+    openAtPointer() {
+        const [x, y] = global.get_pointer();
+        this._dummyCursor.set_position(Math.round(x), Math.round(y));
+        this._dummyCursor.set_size(1, 1);
+        this._boxPointer.setPosition(this._dummyCursor, 0);
+        this._boxPointer.open(BoxPointer.PopupAnimation.FULL);
+    }
+
+    openForEntry(entry) {
+        this._boxPointer.setPosition(entry, 0.5);
+        this._boxPointer.open(BoxPointer.PopupAnimation.FULL);
+    }
+
+    close() {
+        this._boxPointer.close(BoxPointer.PopupAnimation.FULL);
+    }
+});

--- a/js/ui/keyboard.js
+++ b/js/ui/keyboard.js
@@ -868,7 +868,7 @@ const EmojiPager = GObject.registerClass({
     }
 });
 
-const EmojiSelection = GObject.registerClass({
+export const EmojiSelection = GObject.registerClass({
     Signals: {
         'emoji-selected': {param_types: [GObject.TYPE_STRING]},
         'close-request': {},

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -33,6 +33,7 @@ import * as LookingGlass from './lookingGlass.js';
 import * as NotificationDaemon from './notificationDaemon.js';
 import * as WindowAttentionHandler from './windowAttentionHandler.js';
 import * as Screenshot from './screenshot.js';
+import {EmojiPicker} from './emojiPicker.js';
 import * as ScreenShield from './screenShield.js';
 import * as SessionMode from './sessionMode.js';
 import * as ShellDBus from './shellDBus.js';
@@ -73,6 +74,7 @@ export let osdWindowManager = null;
 export let osdMonitorLabeler = null;
 export let sessionMode = null;
 export let screenshotUI = null;
+export let emojiPicker = null;
 export let shellAccessDialogDBusService = null;
 export let shellAudioSelectionDBusService = null;
 export let shellDBusService = null;
@@ -241,6 +243,21 @@ async function _initializeUI() {
         () => global.stage.context.get_backend().set_input_method(null));
 
     screenshotUI = new Screenshot.ScreenshotUI();
+    emojiPicker = new EmojiPicker();
+    emojiPicker.connect('emoji-selected', (_p, emoji) => {
+        let actor = global.stage.get_key_focus();
+        let entry = null;
+        if (actor instanceof St.Entry)
+            entry = actor;
+        else if (actor && actor.get_parent() instanceof St.Entry)
+            entry = actor.get_parent();
+
+        if (entry)
+            entry.clutter_text.insert_text(emoji,
+                entry.clutter_text.get_cursor_position());
+        else
+            St.Clipboard.get_default().set_text(St.ClipboardType.CLIPBOARD, emoji);
+    });
 
     messageTray = new MessageTray.MessageTray();
     panel = new Panel.Panel();

--- a/js/ui/shellEntry.js
+++ b/js/ui/shellEntry.js
@@ -8,6 +8,7 @@ import * as BoxPointer from './boxpointer.js';
 import * as Main from './main.js';
 import * as Params from '../misc/params.js';
 import * as PopupMenu from './popupMenu.js';
+import {EmojiPicker} from './emojiPicker.js';
 
 export class EntryMenu extends PopupMenu.PopupMenu {
     constructor(entry) {
@@ -27,6 +28,11 @@ export class EntryMenu extends PopupMenu.PopupMenu {
         item.connect('activate', this._onPasteActivated.bind(this));
         this.addMenuItem(item);
         this._pasteItem = item;
+
+        item = new PopupMenu.PopupMenuItem(_('Insert Emoji…'));
+        item.connect('activate', this._onEmojiActivated.bind(this));
+        this.addMenuItem(item);
+        this._emojiItem = item;
 
         if (entry instanceof St.PasswordEntry)
             this._makePasswordItem();
@@ -98,6 +104,18 @@ export class EntryMenu extends PopupMenu.PopupMenu {
 
     _onPasswordActivated() {
         this._entry.password_visible  = !this._entry.password_visible;
+    }
+
+    _onEmojiActivated() {
+        if (!this._emojiPicker) {
+            this._emojiPicker = new EmojiPicker();
+            this._emojiPicker.connect('emoji-selected', (_p, emoji) => {
+                let pos = this._entry.clutter_text.get_cursor_position();
+                this._entry.clutter_text.insert_text(emoji, pos);
+            });
+        }
+
+        this._emojiPicker.openForEntry(this._entry);
     }
 }
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -3,6 +3,7 @@
 data/50-gnome-shell-launchers.xml
 data/50-gnome-shell-screenshots.xml
 data/50-gnome-shell-system.xml
+data/50-gnome-shell-emoji.xml
 data/org.gnome.Shell.desktop.in.in
 data/org.gnome.shell.gschema.xml.in
 data/org.gnome.Shell.Extensions.desktop.in.in
@@ -53,6 +54,7 @@ js/ui/overview.js
 js/ui/padOsd.js
 js/ui/panel.js
 js/ui/popupMenu.js
+js/ui/emojiPicker.js
 js/ui/quickSettings.js
 js/ui/runDialog.js
 js/ui/screenShield.js


### PR DESCRIPTION
## Summary
- implement `EmojiPicker` widget derived from EmojiSelection
- add new entry menu item "Insert Emoji…"
- wire global picker with `<Ctrl><Alt>space` and `<Super>.` shortcuts
- hook picker into focused text fields
- install new keybinding metadata and gschema entries

## Testing
- `meson` not installed, so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_6851f7db28488330a77e9261c25a6467